### PR TITLE
Update RemarkCommandParser

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -234,10 +234,12 @@ The `remark` command sets or clears a free-text note on a contact.
 
 - `remark INDEX r/REMARK_TEXT` sets the remark on the person at the displayed index.
 - `remark INDEX r/` clears the existing remark (empty `r/` value).
+- `remark` accepts only one `r/` prefix; repeated `r/` prefixes are rejected as invalid input.
 
 #### Command flow
 
 1. `RemarkCommandParser` parses the one-based index and the `r/` prefix value from the user input.
+    It also validates that `r/` appears at most once.
 2. `RemarkCommand` resolves the target `Person` from `Model#getFilteredPersonList`.
 3. It creates a new `Person` copy via `Person#withRemark(Remark)`, with all other fields unchanged.
 4. `Model#setPerson` replaces the original with the updated copy.
@@ -580,6 +582,11 @@ Priorities: High (must have) - `* * *`, Medium (should have) - `* *`, Low (nice 
     - 1b1. PingBook clears the existing remark on the contact.
 
         Use case ends.
+
+- 1c. User repeats the `r/` prefix.
+    - 1c1. PingBook rejects the command and shows a duplicate-field validation error.
+
+        Use case resumes at step 1.
 
 ---
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -502,6 +502,7 @@ Adds, updates, or removes a free-text note attached to a contact. This is useful
 ##### Format: `remark INDEX r/REMARK`
 
 - To remove an existing remark, type `r/` with nothing after it.
+- Supply `r/` exactly once. Commands with multiple `r/` prefixes are rejected.
 
 ##### Steps
 

--- a/src/main/java/seedu/address/logic/parser/RemarkCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/RemarkCommandParser.java
@@ -24,6 +24,7 @@ public class RemarkCommandParser implements Parser<RemarkCommand> {
     public RemarkCommand parse(String args) throws ParseException {
         requireNonNull(args);
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_REMARK);
+        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_REMARK);
 
         Index index;
         try {

--- a/src/test/java/seedu/address/logic/parser/RemarkCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/RemarkCommandParserTest.java
@@ -1,6 +1,8 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.Messages.getErrorMessageForDuplicatePrefixes;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_REMARK;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
@@ -68,5 +70,14 @@ public class RemarkCommandParserTest {
     public void parse_indexOnlyNoRemarkPrefix_failure() {
         assertParseFailure(parser, " 1",
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, RemarkCommand.MESSAGE_USAGE));
+    }
+
+    /**
+     * Verifies parsing fails when the remark prefix is repeated.
+     */
+    @Test
+    public void parse_multipleRemarks_failure() {
+        assertParseFailure(parser, " 1 r/first r/second",
+                getErrorMessageForDuplicatePrefixes(PREFIX_REMARK));
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The remark command now validates that the `r/` prefix appears exactly once; commands with multiple `r/` prefixes are rejected.

* **Documentation**
  * Updated user and developer guides to specify the requirement that the remark prefix must be supplied exactly once.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->